### PR TITLE
Fix approval reports listing and count refresh

### DIFF
--- a/src/context/UserContext.jsx
+++ b/src/context/UserContext.jsx
@@ -38,20 +38,20 @@ export const UserContextProvider = (props) => {
   
   const refetchCounts = useCallback(async () => {
     const token = localStorage.getItem('ACCESS_TOKEN');
-    if(!token) return;
+    if (!token) return;
 
-    try{
+    try {
       const res = await axiosInstance.get(
-        '${API_BASE_URL}${APPROVAL_SERVICE}/reports/counts',
-        { headers: {Authorization: 'Bearer ${token}'}}
+        `${API_BASE_URL}${APPROVAL_SERVICE}/reports/counts`,
+        { headers: { Authorization: `Bearer ${token}` } },
       );
-      if(res.data?.statusCode === 200){
+      if (res.data?.statusCode === 200) {
         const newCounts = res.data.result;
         setCounts(newCounts);
         localStorage.setItem('APPROVAL_COUNTS', JSON.stringify(newCounts));
       }
-    } catch (err){
-      console.error("문서함 개수 조회 실패:", err);
+    } catch (err) {
+      console.error('문서함 개수 조회 실패:', err);
     }
   }, []);
 

--- a/src/pages/approval/ApprovalBoxList.jsx
+++ b/src/pages/approval/ApprovalBoxList.jsx
@@ -61,15 +61,15 @@ const ApprovalBoxList = () => {
  
       const response = await axiosInstance.get(
         `${API_BASE_URL}${APPROVAL_SERVICE}/reports`,
-        { params } 
+        { params },
       );
- 
-      // 백엔드의 CommonResDto에 맞춰 'data'를 사용하고, 페이징 정보도 저장합니다.
-      if (response.data?.data) {
+
+      // 백엔드의 CommonResDto는 데이터를 'result' 필드로 제공한다.
+      if (response.data?.result) {
         setPageData({
-          reports: response.data.data.reports || [],
-          totalPages: response.data.data.totalPages || 0,
-          totalElements: response.data.data.totalElements || 0,
+          reports: response.data.result.reports || [],
+          totalPages: response.data.result.totalPages || 0,
+          totalElements: response.data.result.totalElements || 0,
         });
       } else {
         setPageData({ reports: [], totalPages: 0, totalElements: 0 });
@@ -91,7 +91,9 @@ const ApprovalBoxList = () => {
   const groupReportsByDate = useCallback((reportsToGroup) => {
     if (!reportsToGroup) return {};
     return reportsToGroup.reduce((acc, report) => {
-      const date = new Date(report.createdAt).toLocaleDateString('ko-KR', {
+      const date = new Date(
+        report.reportCreatedAt || report.createdAt,
+      ).toLocaleDateString('ko-KR', {
         year: 'numeric',
         month: 'long',
         day: 'numeric',
@@ -139,7 +141,7 @@ const ApprovalBoxList = () => {
           {report.name || '정보 없음'}
         </div>
         <div className={styles.itemCell} style={{ flex: 1 }}>
-          {new Date(report.createdAt).toLocaleDateString()}
+          {new Date(report.reportCreatedAt || report.createdAt).toLocaleDateString()}
         </div>
         <div className={styles.itemCell} style={{ flex: 1 }}>
           <span className={`${styles.status} ${styles[report.reportStatus?.toLowerCase() || '']}`}>


### PR DESCRIPTION
## Summary
- Correctly read approval report data from `result` field and support both `reportCreatedAt` and `createdAt`
- Ensure sidebar document counts refresh with proper request URL and auth header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68940ec4883083248200dec1ac3d1018