### PR TITLE
feat: highlight new approval documents in sidebar

### DIFF
--- a/src/pages/approval/Sidebar.jsx
+++ b/src/pages/approval/Sidebar.jsx
@@ -1,6 +1,6 @@
 // /src/pages/approval/Sidebar.jsx
 
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect, useRef } from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
 import styles from './Sidebar.module.scss';
 import { UserContext } from '../../context/UserContext';
@@ -12,8 +12,33 @@ const Sidebar = () => {
   const navigate = useNavigate();
   const { userRole, counts } = useContext(UserContext);
   const [isSelectionModalOpen, setIsSelectionModalOpen] = useState(false);
-  
+
   const safeCounts = counts || {};
+  const prevCountsRef = useRef(safeCounts);
+  const [newFlags, setNewFlags] = useState({});
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      prevCountsRef.current = safeCounts;
+      isFirstRender.current = false;
+      return;
+    }
+
+    const prev = prevCountsRef.current;
+    const updated = { ...newFlags };
+    Object.keys(safeCounts).forEach((key) => {
+      if ((safeCounts[key] || 0) > (prev[key] || 0)) {
+        updated[key] = true;
+      }
+    });
+    prevCountsRef.current = safeCounts;
+    setNewFlags(updated);
+  }, [safeCounts]);
+
+  const handleLinkClick = (key) => {
+    setNewFlags((prev) => ({ ...prev, [key]: false }));
+  };
 
   return (
     <>
@@ -36,45 +61,94 @@ const Sidebar = () => {
             <ul className={styles.menuList}>
               {/* ★★★ data-count 속성을 사용하여 CSS에서 제어하도록 변경 ★★★ */}
               <li>
-                <NavLink to="/approval/pending" className={({ isActive }) => `${styles.menuItem} ${isActive ? styles.active : ''}`}>
+                <NavLink
+                  to="/approval/pending"
+                  className={({ isActive }) => `${styles.menuItem} ${isActive ? styles.active : ''}`}
+                  onClick={() => handleLinkClick('pending')}
+                >
                   <span>결재 예정 문서함</span>
-                  <span className={styles.countBadge} data-count={safeCounts.pending || 0}>{safeCounts.pending || 0}</span>
+                  <span className={styles.badgeContainer}>
+                    <span className={styles.countBadge} data-count={safeCounts.pending || 0}>{safeCounts.pending || 0}</span>
+                    {newFlags.pending && <span className={styles.newBadge}>N</span>}
+                  </span>
                 </NavLink>
               </li>
               <li>
-                <NavLink to="/approval/in-progress" className={({ isActive }) => `${styles.menuItem} ${isActive ? styles.active : ''}`}>
+                <NavLink
+                  to="/approval/in-progress"
+                  className={({ isActive }) => `${styles.menuItem} ${isActive ? styles.active : ''}`}
+                  onClick={() => handleLinkClick('inProgress')}
+                >
                   <span>결재 중 문서함</span>
-                  <span className={styles.countBadge} data-count={safeCounts.inProgress || 0}>{safeCounts.inProgress || 0}</span>
+                  <span className={styles.badgeContainer}>
+                    <span className={styles.countBadge} data-count={safeCounts.inProgress || 0}>{safeCounts.inProgress || 0}</span>
+                    {newFlags.inProgress && <span className={styles.newBadge}>N</span>}
+                  </span>
                 </NavLink>
               </li>
               <li>
-                <NavLink to="/approval/completed" className={({ isActive }) => `${styles.menuItem} ${isActive ? styles.active : ''}`}>
+                <NavLink
+                  to="/approval/completed"
+                  className={({ isActive }) => `${styles.menuItem} ${isActive ? styles.active : ''}`}
+                  onClick={() => handleLinkClick('completed')}
+                >
                   <span>결재 완료 문서함</span>
-                  <span className={styles.countBadge} data-count={safeCounts.completed || 0}>{safeCounts.completed || 0}</span>
+                  <span className={styles.badgeContainer}>
+                    <span className={styles.countBadge} data-count={safeCounts.completed || 0}>{safeCounts.completed || 0}</span>
+                    {newFlags.completed && <span className={styles.newBadge}>N</span>}
+                  </span>
                 </NavLink>
               </li>
               <li>
-                <NavLink to="/approval/rejected" className={({ isActive }) => `${styles.menuItem} ${isActive ? styles.active : ''}`}>
+                <NavLink
+                  to="/approval/rejected"
+                  className={({ isActive }) => `${styles.menuItem} ${isActive ? styles.active : ''}`}
+                  onClick={() => handleLinkClick('rejected')}
+                >
                   <span>반려 문서함</span>
-                  <span className={styles.countBadge} data-count={safeCounts.rejected || 0}>{safeCounts.rejected || 0}</span>
+                  <span className={styles.badgeContainer}>
+                    <span className={styles.countBadge} data-count={safeCounts.rejected || 0}>{safeCounts.rejected || 0}</span>
+                    {newFlags.rejected && <span className={styles.newBadge}>N</span>}
+                  </span>
                 </NavLink>
               </li>
               <li>
-                <NavLink to="/approval/drafts" className={({ isActive }) => `${styles.menuItem} ${isActive ? styles.active : ''}`}>
+                <NavLink
+                  to="/approval/drafts"
+                  className={({ isActive }) => `${styles.menuItem} ${isActive ? styles.active : ''}`}
+                  onClick={() => handleLinkClick('drafts')}
+                >
                   <span>임시 저장 문서함</span>
-                  <span className={styles.countBadge} data-count={safeCounts.drafts || 0}>{safeCounts.drafts || 0}</span>
+                  <span className={styles.badgeContainer}>
+                    <span className={styles.countBadge} data-count={safeCounts.drafts || 0}>{safeCounts.drafts || 0}</span>
+                    {newFlags.drafts && <span className={styles.newBadge}>N</span>}
+                  </span>
                 </NavLink>
               </li>
               <li>
-                <NavLink to="/approval/scheduled" className={({ isActive }) => `${styles.menuItem} ${isActive ? styles.active : ''}`}>
+                <NavLink
+                  to="/approval/scheduled"
+                  className={({ isActive }) => `${styles.menuItem} ${isActive ? styles.active : ''}`}
+                  onClick={() => handleLinkClick('scheduled')}
+                >
                   <span>예약 문서함</span>
-                  <span className={styles.countBadge} data-count={safeCounts.scheduled || 0}>{safeCounts.scheduled || 0}</span>
+                  <span className={styles.badgeContainer}>
+                    <span className={styles.countBadge} data-count={safeCounts.scheduled || 0}>{safeCounts.scheduled || 0}</span>
+                    {newFlags.scheduled && <span className={styles.newBadge}>N</span>}
+                  </span>
                 </NavLink>
               </li>
               <li>
-                <NavLink to="/approval/cc" className={({ isActive }) => `${styles.menuItem} ${isActive ? styles.active : ''}`}>
+                <NavLink
+                  to="/approval/cc"
+                  className={({ isActive }) => `${styles.menuItem} ${isActive ? styles.active : ''}`}
+                  onClick={() => handleLinkClick('cc')}
+                >
                   <span>수신 참조 문서함</span>
-                  <span className={styles.countBadge} data-count={safeCounts.cc || 0}>{safeCounts.cc || 0}</span>
+                  <span className={styles.badgeContainer}>
+                    <span className={styles.countBadge} data-count={safeCounts.cc || 0}>{safeCounts.cc || 0}</span>
+                    {newFlags.cc && <span className={styles.newBadge}>N</span>}
+                  </span>
                 </NavLink>
               </li>
             </ul>

--- a/src/pages/approval/Sidebar.module.scss
+++ b/src/pages/approval/Sidebar.module.scss
@@ -110,23 +110,40 @@
     /* 활성 메뉴의 배지(countBadge)도 흰색으로 변경 */
     .countBadge {
       color: white !important;
+      font-weight: 900;
+    }
+    .newBadge {
+      color: white;
     }
   }
 }
 
 .countBadge {
-  font-size: 15px; /* 폰트 크기를 조금 키워 가독성 향상 */
-  font-weight: 700; /* 항상 굵게 표시 */
-  
-  /* ★★★ 3. 기본 배지 색상은 파란색으로 설정합니다. ★★★ */
-  
+  font-size: 18px; /* 폰트 크기를 크게 조정 */
+  font-weight: 900; /* 더 두껍게 */
+
   transition: opacity 0.3s ease, transform 0.3s ease;
-  
+
   &[data-count="0"] {
     opacity: 0;
     transform: scale(0.5);
     pointer-events: none;
   }
+}
+
+.badgeContainer {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.newBadge {
+  background-color: #dc3545;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700 !important;
+  padding: 2px 4px;
+  border-radius: 4px;
 }
 
 /* ★★★ 4. '결재 예정 문서함'에만 특별한 스타일을 적용합니다. ★★★ */


### PR DESCRIPTION
## Summary
- enlarge approval sidebar count badges and keep them bold
- show red `N` badge when document counts increase

## Testing
- `npm test` *(fails: Missing script "test" but run attempted)*
- `npm run lint` *(fails: ESLint couldn't find config file)*

------
https://chatgpt.com/codex/tasks/task_e_689558f45b388324a0e859ce3b9c0aa4