### PR TITLE
Fix templateId handling for approval submissions

### DIFF
--- a/src/hooks/useApprovalForm.js
+++ b/src/hooks/useApprovalForm.js
@@ -29,7 +29,9 @@ const sanitizeFormData = (data) => {
 
 export const useApprovalForm = (templateId, reportId) => {
   const navigate = useNavigate();
-  
+
+  console.log('[useApprovalForm] init', { templateId, reportId });
+
   const [template, setTemplate] = useState(null);
   const [formData, setFormData] = useState({});
   const [approvalLine, setApprovalLine] = useState([]);
@@ -52,6 +54,7 @@ export const useApprovalForm = (templateId, reportId) => {
       setError(null);
 
       try {
+        console.log('[useApprovalForm] fetchData params:', { templateId, reportId });
         let url;
         // ★ 2. 수정 모드(reportId)인지, 신규 작성 모드(templateId)인지 명확하게 구분합니다.
         if (reportId) {
@@ -77,20 +80,25 @@ export const useApprovalForm = (templateId, reportId) => {
           // 템플릿 정보가 누락되어 있으면 templateId로 추가 조회
           if (data.template) {
             setTemplate(data.template);
+            console.log('[useApprovalForm] template set directly from response:', data.template);
           } else if (data.templateId) {
             // templateId로 템플릿 구조 추가 조회
             try {
               const templateRes = await axiosInstance.get(`${API_BASE_URL}${APPROVAL_SERVICE}/form?templateId=${data.templateId}`);
               if (templateRes.data?.statusCode === 200 && templateRes.data.result?.template) {
                 setTemplate(templateRes.data.result.template);
+                console.log('[useApprovalForm] template fetched using templateId:', templateRes.data.result.template);
               } else {
                 setTemplate(null);
+                console.log('[useApprovalForm] template fetch by templateId failed');
               }
             } catch (e) {
               setTemplate(null);
+              console.log('[useApprovalForm] template fetch error:', e);
             }
           } else {
             setTemplate(null);
+            console.log('[useApprovalForm] no template info in response');
           }
           // formData는 template의 기본값과 실제 데이터를 합쳐서 설정할 수 있습니다.
           // 불필요한 기본값들을 필터링

--- a/src/pages/approval/ApprovalNew.jsx
+++ b/src/pages/approval/ApprovalNew.jsx
@@ -40,6 +40,12 @@ function ApprovalNew() {
 
   // resubmitId가 있으면 reportId 대신 사용
   const effectiveReportId = resubmitId || reportId;
+  console.log('[ApprovalNew] params:', {
+    reportId,
+    templateIdFromQuery,
+    resubmitId,
+    effectiveReportId,
+  });
   const {
     template,
     formData,
@@ -66,8 +72,18 @@ function ApprovalNew() {
   const [isScheduleModalOpen, setIsScheduleModalOpen] = useState(false); // 예약 상신 모달
   const [isScheduling, setIsScheduling] = useState(false); // 예약 상신 중 상태
 
-  
+  useEffect(() => {
+    console.log('[ApprovalNew] template state updated:', template);
+    console.log('[ApprovalNew] current templateId:', template?.templateId);
+  }, [template]);
+
+
   const handleFinalSubmit = useCallback(async (isSubmit = false, isMovingAway = false) => {
+    console.log('[ApprovalNew] handleFinalSubmit invoked', {
+      isSubmit,
+      template,
+      templateId: template?.templateId,
+    });
     // 필수값 유효성 검사
     if (!formData.title || formData.title.trim() === '') {
       await warn({ icon: 'warning', title: '제목은 필수 입력 항목입니다.' });
@@ -113,10 +129,11 @@ function ApprovalNew() {
       // 시나리오 2: 수정 후 '임시 저장' (PUT .../reports/{id})
       method = 'put';
       url = `${API_BASE_URL}${APPROVAL_SERVICE}/reports/${effectiveReportId}`;
+      console.log('[ApprovalNew] using templateId for update:', template?.templateId);
       const updateDto = {
         title: formData.title,
         content: contentValue,
-        templateId: template?.id,
+        templateId: template?.templateId,
         reportTemplateData: JSON.stringify(formData),
         approvalLine: approvalLine.map(a => ({ employeeId: a.id || a.employeeId, approvalContext: a.approvalContext })),
         references: references.map(r => ({ employeeId: r.id || r.employeeId })),
@@ -135,10 +152,11 @@ function ApprovalNew() {
         ? `${API_BASE_URL}${APPROVAL_SERVICE}/submit` // 상신 API
         : `${API_BASE_URL}${APPROVAL_SERVICE}/save`;   // 신규 임시저장 API
 
+      console.log('[ApprovalNew] using templateId for new submission:', template?.templateId);
       const reqDto = {
         title: formData.title,
         content: contentValue,
-        templateId: template?.id,
+        templateId: template?.templateId,
         reportTemplateData: JSON.stringify(formData),
         approvalLine: approvalLine.map(a => ({ employeeId: a.id || a.employeeId, approvalContext: a.approvalContext })),
         references: references.map(r => ({ employeeId: r.id || r.employeeId })),
@@ -328,6 +346,11 @@ function ApprovalNew() {
 
   // 예약 상신 API 호출 함수
   const handleScheduleSubmit = async (scheduledAt) => {
+    console.log('[ApprovalNew] handleScheduleSubmit invoked', {
+      scheduledAt,
+      template,
+      templateId: template?.templateId,
+    });
     // 필수값 유효성 검사
     if (!formData.title || formData.title.trim() === '') {
       await Swal.fire({
@@ -382,12 +405,14 @@ function ApprovalNew() {
           ),
         };
       }
+      console.log('[ApprovalNew] fixedTemplate for scheduling:', fixedTemplate);
+      console.log('[ApprovalNew] fixedTemplate templateId:', fixedTemplate?.templateId);
 
       // 예약 상신 요청 데이터 구성
       reqDto = {
         title: formData.title.trim(),
         content: contentValue.trim(),
-        templateId: fixedTemplate?.id,
+        templateId: fixedTemplate?.templateId,
         reportTemplateData: JSON.stringify(formData),
         approvalLine: approvalLine.map(a => ({ 
           employeeId: a.id || a.employeeId, 


### PR DESCRIPTION
## Summary
- use `template.templateId` rather than `template.id` when building submission payloads
- ensure scheduled submissions reference the correct template id
- add verbose logging for template and templateId to trace submission payloads

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*

------
https://chatgpt.com/codex/tasks/task_e_689769ff71108324ae35b5a835a3cb7f